### PR TITLE
ensures background fills screen on Android

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,8 @@ class DialogInput extends React.Component{
 const styles = StyleSheet.create({
   container:{
     flex:1,
+    width: '100%',
+    height: '100%',
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',


### PR DESCRIPTION
On my app, the background wasn't filling the ensure screen making it look off on Android.